### PR TITLE
Implement deriveImportMap function for deployment models

### DIFF
--- a/.changeset/thick-shoes-repair.md
+++ b/.changeset/thick-shoes-repair.md
@@ -1,0 +1,5 @@
+---
+"@baseplate-sdk/web-app": minor
+---
+
+Implement deriveImportMap function

--- a/backend/DB/Models/DeployedMicrofrontend/DeployedMicrofrontend.ts
+++ b/backend/DB/Models/DeployedMicrofrontend/DeployedMicrofrontend.ts
@@ -7,10 +7,7 @@ import S, {
 } from "sequelize";
 import { BelongsToMethods } from "../SequelizeTSHelpers";
 import { DeploymentModel } from "../Deployment/Deployment";
-import {
-  Microfrontend,
-  MicrofrontendModel,
-} from "../Microfrontend/Microfrontend";
+import { MicrofrontendModel } from "../Microfrontend/Microfrontend";
 import { currentSchema } from "./DeployedMicrofrontendSchema";
 import {
   AuditModel,
@@ -112,7 +109,3 @@ initAuditModel(
   DeployedMicrofrontendModel,
   modelName
 );
-
-export type DeployedMicrofrontendWithMicrofrontend = DeployedMicrofrontend & {
-  microfrontend: Microfrontend;
-};

--- a/backend/DB/Models/DeployedMicrofrontend/DeployedMicrofrontend.ts
+++ b/backend/DB/Models/DeployedMicrofrontend/DeployedMicrofrontend.ts
@@ -7,14 +7,17 @@ import S, {
 } from "sequelize";
 import { BelongsToMethods } from "../SequelizeTSHelpers";
 import { DeploymentModel } from "../Deployment/Deployment";
-import { MicrofrontendModel } from "../Microfrontend/Microfrontend";
+import {
+  Microfrontend,
+  MicrofrontendModel,
+} from "../Microfrontend/Microfrontend";
 import { currentSchema } from "./DeployedMicrofrontendSchema";
 import {
   AuditModel,
   AuditTargetAttributes,
   initAuditModel,
 } from "../Audit/Audit";
-import { UserModel } from "../User";
+import { UserModel } from "../User/User";
 
 const { Model } = S;
 
@@ -32,6 +35,7 @@ export class DeployedMicrofrontendModel
   public id!: number;
   public microfrontendId!: number;
   public deploymentId!: number;
+  public bareImportSpecifier: string;
   public entryUrl!: string;
   public trailingSlashUrl!: string;
   public deploymentChangedMicrofrontend!: boolean;
@@ -59,6 +63,7 @@ export interface DeployedMicrofrontendAttributes extends AuditTargetAttributes {
   id: number;
   deploymentId: number;
   microfrontendId: number;
+  bareImportSpecifier: string;
   entryUrl: string;
   trailingSlashUrl: string;
   deploymentChangedMicrofrontend: boolean;
@@ -107,3 +112,7 @@ initAuditModel(
   DeployedMicrofrontendModel,
   modelName
 );
+
+export type DeployedMicrofrontendWithMicrofrontend = DeployedMicrofrontend & {
+  microfrontend: Microfrontend;
+};

--- a/backend/DB/Models/DeployedMicrofrontend/DeployedMicrofrontendSchema.js
+++ b/backend/DB/Models/DeployedMicrofrontend/DeployedMicrofrontendSchema.js
@@ -35,6 +35,10 @@ const schema = {
     type: DataTypes.BOOLEAN,
     allowNull: false,
   },
+  bareImportSpecifier: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
   entryUrl: {
     type: DataTypes.STRING,
     allowNull: false,

--- a/backend/DB/Models/Deployment/Deployment.test-db.ts
+++ b/backend/DB/Models/Deployment/Deployment.test-db.ts
@@ -5,6 +5,7 @@ import {
   sampleMicrofrontend,
   sampleUser,
 } from "../../TestHelpers/DBTestHelpers";
+import { MicrofrontendModel } from "../Microfrontend/Microfrontend";
 import {
   DeploymentCause,
   DeploymentModel,
@@ -50,5 +51,63 @@ describe("DeploymentModel", () => {
 
     expect(deployment.cause).toBe(DeploymentCause.baseplateWebApp);
     expect(deployment.status).toBe(DeploymentStatus.success);
+  });
+
+  it(`can derive the import map from DeployedMicrofrontend rows`, async () => {
+    try {
+      deployment = await DeploymentModel.create({
+        cause: DeploymentCause.baseplateWebApp,
+        status: DeploymentStatus.success,
+        auditUserId: getUser().id,
+        environmentId: getEnvironment().id,
+      });
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+
+    expect(await deployment.deriveImportMap()).toEqual({
+      imports: {},
+      scopes: {},
+    });
+
+    const microfrontend = await MicrofrontendModel.create({
+      auditUserId: getUser().id,
+      customerOrgId: getCustomerOrg().id,
+      name: "navbar",
+      useCustomerOrgKeyAsScope: true,
+    });
+
+    await deployment.createDeployedMicrofrontend({
+      auditUserId: getUser().id,
+      microfrontendId: microfrontend.id,
+      deploymentChangedMicrofrontend: true,
+      bareImportSpecifier: "@convex/navbar",
+      entryUrl: "https://cdn.baseplate.cloud/convex/apps/navbar/navbar.v1.js",
+      trailingSlashUrl: "https://cdn.baseplate.cloud/convex/apps/navbar/",
+    });
+
+    await deployment.createDeployedMicrofrontend({
+      auditUserId: getUser().id,
+      microfrontendId: microfrontend.id,
+      deploymentChangedMicrofrontend: true,
+      bareImportSpecifier: "@convex/settings",
+      entryUrl:
+        "https://cdn.baseplate.cloud/convex/apps/settings/settings.v1.js",
+      trailingSlashUrl: "https://cdn.baseplate.cloud/convex/apps/settings/",
+    });
+
+    expect(await deployment.deriveImportMap()).toEqual({
+      imports: {
+        "@convex/navbar":
+          "https://cdn.baseplate.cloud/convex/apps/navbar/navbar.v1.js",
+        "@convex/navbar/": "https://cdn.baseplate.cloud/convex/apps/navbar/",
+        "@convex/settings":
+          "https://cdn.baseplate.cloud/convex/apps/settings/settings.v1.js",
+        "@convex/settings/":
+          "https://cdn.baseplate.cloud/convex/apps/settings/",
+      },
+      scopes: {},
+    });
   });
 });

--- a/backend/DB/Models/Deployment/Deployment.test-db.ts
+++ b/backend/DB/Models/Deployment/Deployment.test-db.ts
@@ -109,5 +109,7 @@ describe("DeploymentModel", () => {
       },
       scopes: {},
     });
+
+    await microfrontend.destroy();
   });
 });

--- a/backend/DB/Models/Deployment/Deployment.ts
+++ b/backend/DB/Models/Deployment/Deployment.ts
@@ -3,11 +3,7 @@ import { modelEvents } from "../../../InitDB";
 import { UserModel } from "../User/User";
 import { JWTModel } from "../JWT/JWT";
 import { DeploymentLogModel } from "../DeploymentLog/DeploymentLog";
-import {
-  BelongsToMethods,
-  HasManyMethods,
-  ModelWithIncludes,
-} from "../SequelizeTSHelpers";
+import { BelongsToMethods, HasManyMethods } from "../SequelizeTSHelpers";
 import S, {
   BelongsToGetAssociationMixin,
   BelongsToSetAssociationMixin,
@@ -27,8 +23,6 @@ import { DeployedMicrofrontendModel } from "../DeployedMicrofrontend/DeployedMic
 import { currentSchema } from "./DeploymentSchema";
 import { AuditTargetAttributes } from "../Audit/Audit";
 import { EnvironmentModel } from "../Environment/Environment";
-import { MicrofrontendModel } from "../Microfrontend/Microfrontend";
-import { CustomerOrgModel } from "../CustomerOrg/CustomerOrg";
 
 const { Model } = S;
 

--- a/backend/DB/Models/SequelizeTSHelpers.ts
+++ b/backend/DB/Models/SequelizeTSHelpers.ts
@@ -248,3 +248,8 @@ type CreateBelongsToMany<Aliases, OtherModel extends Model> = {
   [Property in keyof Aliases &
     string as `create${Capitalize<Property>}`]: BelongsToManyCreateAssociationMixin<OtherModel>;
 };
+
+export type ModelWithIncludes<MainModel, IncludedModels> = MainModel & {
+  [Property in keyof IncludedModels &
+    string as Property]: IncludedModels[Property];
+};

--- a/backend/DB/Seeders/20220404174722-microfrontends-deployments.js
+++ b/backend/DB/Seeders/20220404174722-microfrontends-deployments.js
@@ -97,6 +97,53 @@ module.exports = {
         updatedAt: new Date(),
       },
     ]);
+
+    await queryInterface.bulkInsert("DeployedMicrofrontends", [
+      {
+        deploymentId: dep1.id,
+        microfrontendId: navbarMFE.id,
+        deploymentChangedMicrofrontend: true,
+        bareImportSpecifier: "@convex/navbar",
+        entryUrl: "https://cdn.baseplate.cloud/convex/navbar/navbar.v1.js",
+        trailingSlashUrl: "https://cdn.baseplate.cloud/convex/navbar/",
+        auditUserId: sampleUserId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        deploymentId: dep1.id,
+        microfrontendId: settingsMFE.id,
+        deploymentChangedMicrofrontend: true,
+        bareImportSpecifier: "@convex/settings",
+        entryUrl: "https://cdn.baseplate.cloud/convex/settings/settings.v1.js",
+        trailingSlashUrl: "https://cdn.baseplate.cloud/convex/settings/",
+        auditUserId: sampleUserId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        deploymentId: dep1.id,
+        microfrontendId: navbarMFE.id,
+        deploymentChangedMicrofrontend: true,
+        bareImportSpecifier: "@convex/navbar",
+        entryUrl: "https://cdn.baseplate.cloud/convex/navbar/navbar.v2.js",
+        trailingSlashUrl: "https://cdn.baseplate.cloud/convex/navbar/",
+        auditUserId: sampleUserId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+      {
+        deploymentId: dep1.id,
+        microfrontendId: settingsMFE.id,
+        deploymentChangedMicrofrontend: false,
+        bareImportSpecifier: "@convex/settings",
+        entryUrl: "https://cdn.baseplate.cloud/convex/settings/settings.v1.js",
+        trailingSlashUrl: "https://cdn.baseplate.cloud/convex/settings/",
+        auditUserId: sampleUserId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ]);
   },
 
   async down(queryInterface, Sequelize) {


### PR DESCRIPTION
DeploymentModel objects now have a `deriveImportMap` function on them which gives you the import map for any deployment.

See Deployment.test-db.ts for how example of an import map that's generated